### PR TITLE
Add "Const" to types of args in Action

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,7 +1,7 @@
 "PDDL action description."
 struct Action
     name::Symbol # Name of action
-    args::Vector{Var} # Action parameters
+    args::Vector{Term} # Action parameters
     types::Vector{Symbol} # Parameter types
     precond::Term # Precondition of action
     effect::Term # Effect of action

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,7 +1,7 @@
 "PDDL action description."
 struct Action
     name::Symbol # Name of action
-    args::Vector{Term} # Action parameters
+    args::Vector{Union{Const, Var}} # Action parameters
     types::Vector{Symbol} # Parameter types
     precond::Term # Precondition of action
     effect::Term # Effect of action


### PR DESCRIPTION
`get_args(term)` sometimes returns a list that contains `Const`, which cannot be converted to`Var`, causing compiler errors when constructing `Action`. This occurred when trying to use it with POMDPs.jl and MCTS.jl. Changing it to `Union{Const, Var}` solved the issue.